### PR TITLE
BUGFIX: Check existance of the new redirect, before deleting the old one

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -574,6 +574,12 @@ class ModuleController extends AbstractModuleController
             return [];
         }
 
+        $newRedirect = $this->redirectStorage->getOneBySourceUriPathAndHost($sourceUriPath,
+            $host ? $host : null, false);
+        if ($newRedirect !== null) {
+            return [];
+        }
+
         $go = false;
         $redirect = $this->redirectStorage->getOneBySourceUriPathAndHost($originalSourceUriPath,
             $originalHost ? $originalHost : null, false);

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -574,9 +574,10 @@ class ModuleController extends AbstractModuleController
             return [];
         }
 
-        $newRedirect = $this->redirectStorage->getOneBySourceUriPathAndHost($sourceUriPath,
+        // Check for existing redirect with the same properties before changing the edited redirect
+        $existingRedirect = $this->redirectStorage->getOneBySourceUriPathAndHost($sourceUriPath,
             $host ? $host : null, false);
-        if ($newRedirect !== null) {
+        if ($existingRedirect !== null) {
             return [];
         }
 


### PR DESCRIPTION
Create two redirects:
`domain.a, from/a, to/a`
`domain.b, from/a, to/a`

Change the first redirect to `domain.b` too.

Result: The old redirect is deleted, but the new is nto created.

Solution: Stop executing the update, if the "new" redirect already exists.