### PR TITLE
BUGFIX: Allow underscores in source uri

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -12,7 +12,7 @@ Neos:
       initialTypeFilter: 'manual'
       validation:
         # This is the pattern for matching the input in the HTML forms
-        sourceUriPath: '^[a-zA-Z0-9\-\/\.]+$'
+        sourceUriPath: '^[a-zA-Z0-9_\-\/\.]+$'
       csv:
         delimiterOptions: [';', ',', '|']
       statusCodes:

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
         "webexcess/redirecthandler-backend": "*"
     },
     "require": {
-        "neos/redirecthandler": "~3.0 || ~4.0",
-        "neos/neos": "~4.3 || ~5.0",
+        "neos/redirecthandler": "^3.0.1 || ^4.0.2",
+        "neos/neos": "~4.3 || ~5.0", 
         "ext-json": "*"
     },
     "autoload": {


### PR DESCRIPTION
WIthout this it’s not possible to redirect resources
without changing the configuration.

Depends on https://github.com/neos/redirecthandler/pull/34