### PR TITLE
TASK: Simplify csv export action

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -407,25 +407,15 @@ class ModuleController extends AbstractModuleController
         );
         $filename = 'neos-redirects-' . (new DateTime())->format('Y-m-d-H-i-s') . '.csv';
 
-        $filePath = $this->environment->getPathToTemporaryDirectory() . $filename;
-
-        file_put_contents($filePath, $csvWriter->getContent());
-
+        $content = $csvWriter->getContent();
         header("Pragma: no-cache");
         header("Content-type: application/text");
-        header("Content-Length: " . filesize($filePath));
+        header("Content-Length: " . strlen($content));
         header("Content-Disposition: attachment; filename=" . $filename);
-        header('Content-Transfer-Encoding: binary');
-        header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
+        header("Content-Transfer-Encoding: binary");
+        header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 
-        readfile($filePath);
-
-        // Remove file again
-        if (file_exists($filePath)) {
-            unlink($filePath);
-        }
-
-        exit;
+        return $content;
     }
 
     /**

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -415,7 +415,9 @@ class ModuleController extends AbstractModuleController
         header("Content-Transfer-Encoding: binary");
         header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 
-        return $content;
+        echo $content;
+
+        exit;
     }
 
     /**

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -408,12 +408,12 @@ class ModuleController extends AbstractModuleController
         $filename = 'neos-redirects-' . (new DateTime())->format('Y-m-d-H-i-s') . '.csv';
 
         $content = $csvWriter->getContent();
-        header("Pragma: no-cache");
-        header("Content-type: application/text");
-        header("Content-Length: " . strlen($content));
-        header("Content-Disposition: attachment; filename=" . $filename);
-        header("Content-Transfer-Encoding: binary");
-        header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
+        header('Pragma: no-cache');
+        header('Content-type: application/text');
+        header('Content-Length: ' . strlen($content));
+        header('Content-Disposition: attachment; filename=' . $filename);
+        header('Content-Transfer-Encoding: binary');
+        header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
 
         echo $content;
 


### PR DESCRIPTION
No need to write to file, `readfile` that, delete it and exit forcefully

Fixes #33 