### PR TITLE
BUGFIX: clipBoardCopyLabel translation

### DIFF
--- a/Resources/Private/Translations/en/Modules.xlf
+++ b/Resources/Private/Translations/en/Modules.xlf
@@ -306,7 +306,7 @@
             </trans-unit>
             <trans-unit id="clipBoardCopyLabel" xml:space="preserve">
                 <source>Copy</source>
-                <target>Kopieren</target>
+                <target>Copy</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
This was actually added in a broken way, with the english label using a german translation…